### PR TITLE
Add nsheff as recipe maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,3 +52,4 @@ about:
 extra:
   recipe-maintainers:
     - mencian
+    - nsheff


### PR DESCRIPTION
Adding myself as a maintainer for the pipestat feedstock. I am the upstream maintainer of pipestat at https://github.com/pepkit/pipestat.